### PR TITLE
Fix bcrypt build errors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ addons:
     - mongodb-3.2-precise
     packages:
     - mongodb-org-server
+    - build-essential
+    - python-2.7


### PR DESCRIPTION
Bcrypt needs tools to setup under Ubuntu (basically, build-essentials).
http://stackoverflow.com/questions/25848475/unable-to-install-npm-bcrypt-on-ubuntu
